### PR TITLE
Created base of the contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa1715a9b71c7c31385a3f021dee2fd0a17b82043ab937467e103aa25043d2e"
+checksum = "4ec9bdd1f4da5fc0d085251b0322661c5aaf773ab299e3e205fb18130b7f6ba3"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f6e6dff07965015c4fcdf477c4becde738a2bfb40cf6239bdcea9335016c5a2"
+checksum = "5ac17a14b4ab09a5d89b5301218067acca33d9311376e5c34c9877f09e562395"
 dependencies = [
  "syn",
 ]
@@ -69,9 +69,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92bdeee0ebba164ebbef9380522cc50f889db38acc1f1210f6b55ee2244b8c59"
+checksum = "e47306c113f4d964c35a74a87ceb8ccfb5811e9810a9dc427101148b5b9134ca"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -145,11 +145,23 @@ dependencies = [
 
 [[package]]
 name = "cw-storage-plus"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef70f7912bed72ff56a4f704aee279b6ef4cd0a5f3aa2732ad371e3f6d3ea71"
+checksum = "c1e867b9972b83b32e00e878dfbff48299ba26618dabeb19b9c56fae176dc225"
 dependencies = [
  "cosmwasm-std",
+ "schemars",
+ "serde",
+]
+
+[[package]]
+name = "cw2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d48454f96494aa1018556cd457977375cc8c57ef3e5c767cfa2ea5ec24b0258"
+dependencies = [
+ "cosmwasm-std",
+ "cw-storage-plus",
  "schemars",
  "serde",
 ]
@@ -330,25 +342,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
-dependencies = [
- "unicode-xid",
-]
-
-[[package]]
-name = "project-name"
+name = "primitive-contract"
 version = "0.1.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-storage-plus",
+ "cw2",
  "schemars",
  "serde",
  "thiserror",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+dependencies = [
+ "unicode-xid",
 ]
 
 [[package]]

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -3,8 +3,10 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use primitive_contract::msg::{CountResponse, ExecuteMsg, InstantiateMsg, QueryMsg};
-use primitive_contract::state::State;
+use primitive_contract::msg::{
+    ConfigResponse, ExecuteMsg, GetValueResponse, InstantiateMsg, QueryMsg,
+};
+use primitive_contract::state::Config;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -15,6 +17,7 @@ fn main() {
     export_schema(&schema_for!(InstantiateMsg), &out_dir);
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
-    export_schema(&schema_for!(State), &out_dir);
-    export_schema(&schema_for!(CountResponse), &out_dir);
+    export_schema(&schema_for!(Config), &out_dir);
+    export_schema(&schema_for!(GetValueResponse), &out_dir);
+    export_schema(&schema_for!(ConfigResponse), &out_dir);
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,11 +9,9 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized {},
 
-    #[error("PrimitiveExists")]
-    PrimitiveExists {},
+    #[error("ContainerExists")]
+    ContainerExists {},
 
-    #[error("PrimitiveDoesNotExists")]
-    PrimitiveDoesNotExist {},
-    // Add any other custom errors you like here.
-    // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
+    #[error("ContainerDoesNotExist")]
+    ContainerDoesNotExist {},
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,12 @@ pub enum ContractError {
 
     #[error("Unauthorized")]
     Unauthorized {},
+
+    #[error("PrimitiveExists")]
+    PrimitiveExists {},
+
+    #[error("PrimitiveDoesNotExists")]
+    PrimitiveDoesNotExist {},
     // Add any other custom errors you like here.
     // Look at https://docs.rs/thiserror/1.0.21/thiserror/ for details.
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,27 +1,26 @@
+use crate::state::Primitive;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InstantiateMsg {
-    pub count: i32,
-}
+pub struct InstantiateMsg {}
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    Increment {},
-    Reset { count: i32 },
+    AddValue { name: String, value: Primitive },
+    UpdateValue { name: String, value: Primitive },
+    DeleteValue { name: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    // GetCount returns the current count as a json-encoded number
-    GetCount {},
+    GetValue { name: String },
 }
 
-// We define a custom struct for each query response
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct CountResponse {
-    pub count: i32,
+pub struct GetValueResponse {
+    pub name: String,
+    pub value: Primitive,
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,4 +1,5 @@
 use crate::state::Primitive;
+use cosmwasm_std::Addr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -8,19 +9,24 @@ pub struct InstantiateMsg {}
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    AddValue { name: String, value: Primitive },
-    UpdateValue { name: String, value: Primitive },
+    SetValue { name: String, value: Primitive },
     DeleteValue { name: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    GetValue { name: String },
+    Config {},
+    GetValue { address: Addr, name: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetValueResponse {
     pub name: String,
     pub value: Primitive,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ConfigResponse {
+    pub owner: Addr,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,10 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::{Item, Map};
-use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct State {
+pub struct Config {
     pub owner: Addr,
 }
 
@@ -17,5 +16,5 @@ pub enum Primitive {
     Bool(bool),
 }
 
-pub const DATA: Map<Addr, HashMap<String, Primitive>> = Map::new("data");
-pub const STATE: Item<State> = Item::new("state");
+pub const DATA: Map<(&Addr, &str), Primitive> = Map::new("data");
+pub const CONFIG: Item<Config> = Item::new("config");

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,13 +1,21 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::Addr;
-use cw_storage_plus::Item;
+use cosmwasm_std::{Addr, Uint128};
+use cw_storage_plus::{Item, Map};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct State {
-    pub count: i32,
     pub owner: Addr,
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub enum Primitive {
+    Uint128(Uint128),
+    String(String),
+    Bool(bool),
+}
+
+pub const DATA: Map<Addr, HashMap<String, Primitive>> = Map::new("data");
 pub const STATE: Item<State> = Item::new("state");

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,7 +1,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use cosmwasm_std::{Addr, Uint128};
+use cosmwasm_std::{Addr, StdError, Uint128};
 use cw_storage_plus::{Item, Map};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -16,5 +16,92 @@ pub enum Primitive {
     Bool(bool),
 }
 
+fn parse_error(type_name: String) -> StdError {
+    StdError::ParseErr {
+        target_type: type_name.clone(),
+        msg: format!("Primitive is not a {}", type_name),
+    }
+}
+
+// These are methods to help the calling user quickly retreive the data in the Primitive as they
+// often already know what the type should be.
+impl Primitive {
+    pub fn try_get_uint128(&self) -> Result<Uint128, StdError> {
+        match self {
+            Primitive::Uint128(value) => Ok(*value),
+            _ => Err(parse_error(String::from("Uint128"))),
+        }
+    }
+
+    pub fn try_get_string(&self) -> Result<String, StdError> {
+        match self {
+            Primitive::String(value) => Ok(value.to_string()),
+            _ => Err(parse_error(String::from("String"))),
+        }
+    }
+
+    pub fn try_get_bool(&self) -> Result<bool, StdError> {
+        match self {
+            Primitive::Bool(value) => Ok(*value),
+            _ => Err(parse_error(String::from("bool"))),
+        }
+    }
+}
+
 pub const DATA: Map<(&Addr, &str), Primitive> = Map::new("data");
 pub const CONFIG: Item<Config> = Item::new("config");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_error() {
+        assert_eq!(
+            StdError::ParseErr {
+                target_type: "target_type".to_string(),
+                msg: "Primitive is not a target_type".to_string()
+            },
+            parse_error("target_type".to_string())
+        );
+    }
+
+    #[test]
+    fn try_get_uint128() {
+        let primitive = Primitive::Uint128(Uint128::from(5 as u128));
+        assert_eq!(
+            Uint128::from(5 as u128),
+            primitive.try_get_uint128().unwrap()
+        );
+
+        let primitive = Primitive::Bool(true);
+        assert_eq!(
+            parse_error("Uint128".to_string()),
+            primitive.try_get_uint128().unwrap_err()
+        );
+    }
+
+    #[test]
+    fn try_get_string() {
+        let primitive = Primitive::String("String".to_string());
+        assert_eq!("String".to_string(), primitive.try_get_string().unwrap());
+
+        let primitive = Primitive::Bool(true);
+        assert_eq!(
+            parse_error("String".to_string()),
+            primitive.try_get_string().unwrap_err()
+        );
+    }
+
+    #[test]
+    fn try_get_bool() {
+        let primitive = Primitive::Bool(true);
+        assert_eq!(true, primitive.try_get_bool().unwrap());
+
+        let primitive = Primitive::String("String".to_string());
+        assert_eq!(
+            parse_error("bool".to_string()),
+            primitive.try_get_bool().unwrap_err()
+        );
+    }
+}


### PR DESCRIPTION
I decided to store the primitives using an enum to be able to differentiate between the types easily. It is really easy to add more primitives as you just need to add another value to the enum and a simple helper method (to make the end user's life easier). The general form is
```
enum Primitive {
   ...
   Type(Type)
   ...
}
```
The data itself is stored as a `Map<(&Addr, &str), Primitive>` where the key is a tuple containing the address that owns this primitive and the name of the primitive (the names are unique across a user's primitives, but globally multiple users can have the same primitive name).

There are two execute messages, `SetValue { name: String, value: Primitive }` and `DeleteValue { name: String }` which do what their names suggest. The address is grabbed from the `info.sender` field. This has the benefit of only allowing the owner of a given primitive to modify it.

There are two queries, `GetValue { address: Addr, name: String }` and `Config {}`. The config one gets the config (just the owner of the contract at the moment) and `GetValue` returns the primitive of that address and name if it exists (error otherwise). I contemplated adding another query which lists all primitives for a given address as that might be useful for an end user, but I decided to stick with this base for now and can add it in a future PR if we want it. 

I tried to get Vec to also work with this but I couldn't figure out how to have a dynamic type for it. What we could do is support a few common vectors like `Vec<u8>` for bytes for instance, open to feedback for this. It should also be possible to support all of the integer types if we want them (with a similar implementation as for Uint128) but I left them out for this PR. 